### PR TITLE
[Proposal] v2.2.0 `file` Node

### DIFF
--- a/model-desc/ins-model-props.yml
+++ b/model-desc/ins-model-props.yml
@@ -5,6 +5,7 @@ PropDefinitions:
   program_id:
     Desc: program id
     Type: string
+    Key: true
     Req: true
     Private: true
   program_name:
@@ -117,6 +118,7 @@ PropDefinitions:
   grant_id: 
     Desc: full id with leading numeral and suffix
     Type: string
+    Key: true
     Req: true
     Private: false
   application_id:
@@ -208,6 +210,7 @@ PropDefinitions:
   project_id:
     Desc: core id (no leading numeral or suffix)
     Type: string
+    Key: true
     Req: true
     Private: false
   project_title:
@@ -259,6 +262,7 @@ PropDefinitions:
   pmid:
     Desc: PubMed ID
     Type: string
+    Key: true    
     Req: true
     Private: false
   publication_title:

--- a/model-desc/ins-model-props.yml
+++ b/model-desc/ins-model-props.yml
@@ -415,6 +415,9 @@ PropDefinitions:
     Private: false
   related_terms:
     Desc: any terms related to the dataset study
+    Type: string  # list
+    Req: false  # may not be available
+    Private: false    
   # Properties of file:
   file_id:
     Desc: Unique file identifier (UUID)

--- a/model-desc/ins-model-props.yml
+++ b/model-desc/ins-model-props.yml
@@ -290,6 +290,7 @@ PropDefinitions:
   dataset_uuid:
     Desc: INS internal dataset id
     Type: string
+    Key: true
     Req: true
     Private: true
   dataset_source_repo:
@@ -418,6 +419,7 @@ PropDefinitions:
   file_id:
     Desc: Unique file identifier (UUID)
     Type: string
+    Key: true
     Req: true
     Private: false
   file_name:

--- a/model-desc/ins-model-props.yml
+++ b/model-desc/ins-model-props.yml
@@ -414,6 +414,48 @@ PropDefinitions:
     Private: false
   related_terms:
     Desc: any terms related to the dataset study
-    Type: string  # list
-    Req: false  # may not be available
+  # Properties of file:
+  file_id:
+    Desc: Unique file identifier (UUID)
+    Type: string
+    Req: true
+    Private: false
+  file_name:
+    Desc: The literal label for an electronic data file.
+    Term:
+      - Origin: caDSR
+        Code: "11284037"
+        Value: Electronic Data File Name
+        Version: "2.0"
+    Type: string
+    Req: true
+    Private: false
+  file_type:
+    Desc: File extension/format
+    Term:
+      - Origin: caDSR
+        Code: "11416926"
+        Value: Electronic Data File Format Type
+        Version: "1.00"
+    Type: string
+    Req: false
+    Private: false
+  file_url:
+    Desc: The specification of a node (file or directory) in a hierarchical file system where an electronic file is located.
+    Term:
+      - Origin: caDSR
+        Code: "11556141"
+        Value: Electronic File Pathname Text
+        Version: "2.00"
+    Type: string
+    Req: true
+    Private: false
+  access_level:
+    Desc: Access control level
+    Type:
+      value_type: string
+      Enum:
+        - Open
+        - Controlled
+    Req: true
     Private: false

--- a/model-desc/ins-model.yml
+++ b/model-desc/ins-model.yml
@@ -1,5 +1,5 @@
 Handle: INS
-Version: 2.1.0
+Version: 2.2.0
 Nodes:
   program:
     Props:
@@ -85,6 +85,13 @@ Nodes:
       - related_genes
       - related_diseases
       - related_terms
+  file:
+    Props:
+      - file_id
+      - file_name
+      - file_type
+      - file_url
+      - access_level
 Relationships:
   has_publication:
     Mul: many_to_many
@@ -103,4 +110,10 @@ Relationships:
     Ends:
       - Src: project
         Dst: program
+    Props: null
+  files_of_dataset:
+    Mul: many_to_one
+    Ends:
+      - Src: file
+        Dst: dataset
     Props: null


### PR DESCRIPTION
### Overview

This PR introduces a proposed `file` (data file) node to the INS data model. This new node has a small subset of the traditional fields to meet our current needs, but could be expanded in the future.

> [!Warning]
> We historically have not used CDEs in INS, but I borrowed some of the properties from the CCDI data model, which already had them. If we want to be consistent with the rest of our properties, I can remove the CDEs.

> [!Note]
> Attached are two files derived from the data model navigator.
> - [INS-Data-Dictionary-File.pdf](https://github.com/user-attachments/files/23657973/INS-Data-Dictionary-File.pdf)
> - [INS-File-Loading-Template-v2.2.0.tsv](https://github.com/user-attachments/files/23657890/INS-File-Loading-Template-v2.2.0.tsv)

> [!Note]
> <img width="646" height="335" alt="image" src="https://github.com/user-attachments/assets/429b5a68-bb33-4ebd-9e83-b7f3bfd99414" />

### Change Details (Specifics)

- Fix: `dataset` has no key property defined
- Add new `file` node with core properties to handle the CTD2 data file download functionality
  - file_id – A UUID of the Data File
  - file_name – The original name of the Data File
  - file_type – The type of the data file (CDE: [11416926](https://cadsr.cancer.gov/onedata/dmdirect/NIH/NCI/CO/CDEDD?filter=CDEDD.ITEM_ID=11416926%20and%20ver_nr=1.00))
  - file_url – The full pathname of the Data File in the S3 bucket (e.g. "CTD2/FolderXX/DatafileXyz.zip")
  - access_level – "Open" or "Controlled", for CTD2, always "Open"

### Related Ticket(s)

[INS-1480](https://tracker.nci.nih.gov/browse/INS-1480)