### PR TITLE
INS-1481: Add new CTD2 props to dataset node

### DIFF
--- a/model-desc/ins-model-props.yml
+++ b/model-desc/ins-model-props.yml
@@ -347,6 +347,16 @@ PropDefinitions:
     Type: string  # list
     Req: false 
     Private: false
+  POC_name:
+    Desc: dataset point of contact name
+    Type: string
+    Req: false 
+    Private: true # not displayed
+  POC_email:
+    Desc: dataset point of contact email
+    Type: string
+    Req: false 
+    Private: true # not displayed
   dataset_maximum_age_at_baseline:
     Desc: oldest participant age at baseline
     Type: integer

--- a/model-desc/ins-model-props.yml
+++ b/model-desc/ins-model-props.yml
@@ -312,6 +312,11 @@ PropDefinitions:
     Type: string
     Req: true
     Private: false
+  experimental_approaches:
+    Desc: experimental approaches used in dataset
+    Type: string
+    Req: false
+    Private: false
   dataset_source_id:
     Desc: e.g., dbGaP accession, GEO or SRA IDs
     Type: string
@@ -321,6 +326,11 @@ PropDefinitions:
     Desc: study web page URL
     Type: string
     Req: true
+    Private: false
+  institute:
+    Desc: institute contributing the dataset
+    Type: string
+    Req: false
     Private: false
   PI_name:
     Desc: dataset primary investigator name(s)

--- a/model-desc/ins-model.yml
+++ b/model-desc/ins-model.yml
@@ -70,6 +70,8 @@ Nodes:
       - PI_name
       - GPA  # Grant Program Administrator name; not displayed
       - dataset_doc
+      - POC_name # not displayed
+      - POC_email # not displayed
       - dataset_maximum_age_at_baseline
       - dataset_minimum_age_at_baseline
       - dataset_pmid

--- a/model-desc/ins-model.yml
+++ b/model-desc/ins-model.yml
@@ -63,8 +63,10 @@ Nodes:
       - dataset_source_repo  # e.g., dbGaP, GEO, SRA
       - dataset_title
       - description
+      - experimental_approaches
       - dataset_source_id
       - dataset_source_url
+      - institute
       - PI_name
       - GPA  # Grant Program Administrator name; not displayed
       - dataset_doc


### PR DESCRIPTION
- Add `experimental approaches` and `institute` to `ins-model.yml` and `ins-model-props.yml`
- Both are strings (not list-like) and not required