### PR TITLE
2.2.0

### DIFF
--- a/model-desc/ins-model-props.yml
+++ b/model-desc/ins-model-props.yml
@@ -347,6 +347,16 @@ PropDefinitions:
     Type: string  # list
     Req: false 
     Private: false
+  POC_name:
+    Desc: dataset point of contact name
+    Type: string
+    Req: false 
+    Private: true # not displayed
+  POC_email:
+    Desc: dataset point of contact email
+    Type: string
+    Req: false 
+    Private: true # not displayed
   dataset_maximum_age_at_baseline:
     Desc: oldest participant age at baseline
     Type: integer

--- a/model-desc/ins-model-props.yml
+++ b/model-desc/ins-model-props.yml
@@ -325,7 +325,7 @@ PropDefinitions:
   dataset_source_url:
     Desc: study web page URL
     Type: string
-    Req: true
+    Req: false
     Private: false
   institute:
     Desc: institute contributing the dataset

--- a/model-desc/ins-model-props.yml
+++ b/model-desc/ins-model-props.yml
@@ -5,6 +5,7 @@ PropDefinitions:
   program_id:
     Desc: program id
     Type: string
+    Key: true
     Req: true
     Private: true
   program_name:
@@ -117,6 +118,7 @@ PropDefinitions:
   grant_id: 
     Desc: full id with leading numeral and suffix
     Type: string
+    Key: true
     Req: true
     Private: false
   application_id:
@@ -208,6 +210,7 @@ PropDefinitions:
   project_id:
     Desc: core id (no leading numeral or suffix)
     Type: string
+    Key: true
     Req: true
     Private: false
   project_title:
@@ -259,6 +262,7 @@ PropDefinitions:
   pmid:
     Desc: PubMed ID
     Type: string
+    Key: true    
     Req: true
     Private: false
   publication_title:

--- a/model-desc/ins-model-props.yml
+++ b/model-desc/ins-model-props.yml
@@ -415,6 +415,9 @@ PropDefinitions:
     Private: false
   related_terms:
     Desc: any terms related to the dataset study
+    Type: string  # list
+    Req: false  # may not be available
+    Private: false    
   # Properties of file:
   file_id:
     Desc: Unique file identifier (UUID)

--- a/model-desc/ins-model-props.yml
+++ b/model-desc/ins-model-props.yml
@@ -312,6 +312,11 @@ PropDefinitions:
     Type: string
     Req: true
     Private: false
+  experimental_approaches:
+    Desc: experimental approaches used in dataset
+    Type: string
+    Req: false
+    Private: false
   dataset_source_id:
     Desc: e.g., dbGaP accession, GEO or SRA IDs
     Type: string
@@ -321,6 +326,11 @@ PropDefinitions:
     Desc: study web page URL
     Type: string
     Req: true
+    Private: false
+  institute:
+    Desc: institute contributing the dataset
+    Type: string
+    Req: false
     Private: false
   PI_name:
     Desc: dataset primary investigator name(s)

--- a/model-desc/ins-model-props.yml
+++ b/model-desc/ins-model-props.yml
@@ -290,6 +290,7 @@ PropDefinitions:
   dataset_uuid:
     Desc: INS internal dataset id
     Type: string
+    Key: true
     Req: true
     Private: true
   dataset_source_repo:
@@ -418,6 +419,7 @@ PropDefinitions:
   file_id:
     Desc: Unique file identifier (UUID)
     Type: string
+    Key: true
     Req: true
     Private: false
   file_name:

--- a/model-desc/ins-model-props.yml
+++ b/model-desc/ins-model-props.yml
@@ -414,6 +414,48 @@ PropDefinitions:
     Private: false
   related_terms:
     Desc: any terms related to the dataset study
-    Type: string  # list
-    Req: false  # may not be available
+  # Properties of file:
+  file_id:
+    Desc: Unique file identifier (UUID)
+    Type: string
+    Req: true
+    Private: false
+  file_name:
+    Desc: The literal label for an electronic data file.
+    Term:
+      - Origin: caDSR
+        Code: "11284037"
+        Value: Electronic Data File Name
+        Version: "2.0"
+    Type: string
+    Req: true
+    Private: false
+  file_type:
+    Desc: File extension/format
+    Term:
+      - Origin: caDSR
+        Code: "11416926"
+        Value: Electronic Data File Format Type
+        Version: "1.00"
+    Type: string
+    Req: false
+    Private: false
+  file_url:
+    Desc: The specification of a node (file or directory) in a hierarchical file system where an electronic file is located.
+    Term:
+      - Origin: caDSR
+        Code: "11556141"
+        Value: Electronic File Pathname Text
+        Version: "2.00"
+    Type: string
+    Req: true
+    Private: false
+  access_level:
+    Desc: Access control level
+    Type:
+      value_type: string
+      Enum:
+        - Open
+        - Controlled
+    Req: true
     Private: false

--- a/model-desc/ins-model.yml
+++ b/model-desc/ins-model.yml
@@ -70,6 +70,8 @@ Nodes:
       - PI_name
       - GPA  # Grant Program Administrator name; not displayed
       - dataset_doc
+      - POC_name # not displayed
+      - POC_email # not displayed
       - dataset_maximum_age_at_baseline
       - dataset_minimum_age_at_baseline
       - dataset_pmid

--- a/model-desc/ins-model.yml
+++ b/model-desc/ins-model.yml
@@ -63,8 +63,10 @@ Nodes:
       - dataset_source_repo  # e.g., dbGaP, GEO, SRA
       - dataset_title
       - description
+      - experimental_approaches
       - dataset_source_id
       - dataset_source_url
+      - institute
       - PI_name
       - GPA  # Grant Program Administrator name; not displayed
       - dataset_doc

--- a/model-desc/ins-model.yml
+++ b/model-desc/ins-model.yml
@@ -1,5 +1,5 @@
 Handle: INS
-Version: 2.1.0
+Version: 2.2.0
 Nodes:
   program:
     Props:
@@ -85,6 +85,13 @@ Nodes:
       - related_genes
       - related_diseases
       - related_terms
+  file:
+    Props:
+      - file_id
+      - file_name
+      - file_type
+      - file_url
+      - access_level
 Relationships:
   has_publication:
     Mul: many_to_many
@@ -103,4 +110,10 @@ Relationships:
     Ends:
       - Src: project
         Dst: program
+    Props: null
+  files_of_dataset:
+    Mul: many_to_one
+    Ends:
+      - Src: file
+        Dst: dataset
     Props: null


### PR DESCRIPTION
# INS Data Model 2.2.0 Release
This model release was used along with [INS-Data Release 2.2.0](https://github.com/CBIIT/INS-Data/releases/tag/2.2.0) for the release of the [Index of NCI Studies](https://studycatalog.cancer.gov/) version 3.2.0 on December 18, 2025.

## Key Changes
* Add new `file` node to support associating downloadable files with parent datasets
* Update `dataset` properties to support new datasets from the Cancer Target Discovery and Development (CTD²) Network
* Add explicit `key` values to all nodes